### PR TITLE
Improve parquet gzip compression performance

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -50,7 +50,7 @@ bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
 snap = { version = "1.0", default-features = false, optional = true }
 brotli = { version = "7.0", default-features = false, features = ["std"], optional = true }
-flate2 = { version = "1.0", default-features = false, features = ["rust_backend"], optional = true }
+flate2 = { version = "1.0", default-features = false, features = ["zlib-ng"], optional = true }
 lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }
 chrono = { workspace = true }


### PR DESCRIPTION
```
compress GZIP(GzipLevel(6)) - alphanumeric
                        time:   [25.866 ms 26.802 ms 28.124 ms]
                        change: [-24.081% -20.998% -17.552%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

GZIP(GzipLevel(6)) compressed 1048576 bytes of alphanumeric to 785084 bytes
decompress GZIP(GzipLevel(6)) - alphanumeric
                        time:   [3.3236 ms 3.3921 ms 3.4753 ms]
                        change: [-12.756% -10.427% -8.0441%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

LZ4 compressed 1048576 bytes of alphanumeric to 1052698 bytes
LZ4_RAW compressed 1048576 bytes of alphanumeric to 1052690 bytes
SNAPPY compressed 1048576 bytes of alphanumeric to 1048627 bytes
compress GZIP(GzipLevel(6)) - alphanumeric #2
                        time:   [26.058 ms 26.519 ms 27.056 ms]
                        change: [-26.879% -24.491% -22.106%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

GZIP(GzipLevel(6)) compressed 1048576 bytes of alphanumeric to 785084 bytes
decompress GZIP(GzipLevel(6)) - alphanumeric #2
                        time:   [3.2376 ms 3.3290 ms 3.4507 ms]
                        change: [-17.234% -14.592% -11.125%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

ZSTD(ZstdLevel(1)) compressed 1048576 bytes of alphanumeric to 782315 bytes
BROTLI(BrotliLevel(1)) compressed 1048576 bytes of words to 280547 bytes
compress GZIP(GzipLevel(6)) - words
                        time:   [25.619 ms 26.035 ms 26.557 ms]
                        change: [-42.054% -40.589% -39.081%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

GZIP(GzipLevel(6)) compressed 1048576 bytes of words to 236887 bytes
Benchmarking decompress GZIP(GzipLevel(6)) - words: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.1s, enable flat sampling, or reduce sample count to 50.
decompress GZIP(GzipLevel(6)) - words
                        time:   [1.5657 ms 1.6135 ms 1.6784 ms]
                        change: [-52.033% -50.387% -48.446%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

LZ4 compressed 1048576 bytes of words to 408369 bytes
LZ4_RAW compressed 1048576 bytes of words to 408361 bytes
SNAPPY compressed 1048576 bytes of words to 347626 bytes
compress GZIP(GzipLevel(6)) - words #2
                        time:   [25.389 ms 25.800 ms 26.288 ms]
                        change: [-40.070% -38.459% -36.837%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

GZIP(GzipLevel(6)) compressed 1048576 bytes of words to 236887 bytes
Benchmarking decompress GZIP(GzipLevel(6)) - words #2: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.8s, enable flat sampling, or reduce sample count to 50.
decompress GZIP(GzipLevel(6)) - words #2
                        time:   [1.5322 ms 1.5596 ms 1.6010 ms]
                        change: [-51.219% -49.979% -48.696%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

ZSTD(ZstdLevel(1)) compressed 1048576 bytes of words to 272814 bytes
```